### PR TITLE
feat:  allows to set screen geometry

### DIFF
--- a/xcalibrate
+++ b/xcalibrate
@@ -52,6 +52,16 @@ def choose_dev(devs, preferred):
         if dev in devs.keys():
             return dev
 
+def choose_int(description, default):
+    while True:
+        p_str = input(description +' [%d]: ' % (default))
+        if not p_str:
+            return default
+        try:
+            p = int(p_str)
+        except ValueError:
+            continue
+        return p
 
 def read_cal(dev):
     stdout = xinput('--list-props', str(dev))
@@ -104,8 +114,12 @@ def show_tk(n_points, old_cal_inv, new_cal=None):
     root.attributes('-fullscreen', True)
     # as the above line doesn't work on all screens
     # we force the geometry to be the fullsize with next two lines
-    w,h = root.winfo_screenwidth(), root.winfo_screenheight()
-    root.geometry("%dx%d" % (w,h))
+    w = choose_int('Screen width', root.winfo_screenwidth())
+    h = choose_int('Screen height', root.winfo_screenheight())
+    xoff = choose_int('Screen X-offset', 0)
+    yoff = choose_int('Screen Y-offset', 0)
+    root.geometry("%dx%d+%d+%d" % (w, h, xoff, yoff))
+    print("Geometry: %dx%d+%d+%d" % (w, h, xoff, yoff))
     canvas = Canvas(root)
 
     def resize(event):


### PR DESCRIPTION
When we have multiple monitors, and only one of them is a touchscreen, we have to be able to define the width, height, xoffset yoffset of the area that will actually be used by the touch screen to create the calibration window. 
Example if we have two 800x600 monitors X-Window will be considered as a screen size of width x height: 1600x200, creating a cambas with "1600x800" geometry
However, the touchscreen monitor is X-offset 800, so the correct geometry should be "800x600+800+0"
This PR allows you to override and introduce the detected screen width and height and indicate the XOFF and YOFF offset values that will be used by Canvas for calibration.

Example based on two 800x600 monitors, where the touchsreen is at xoffset 800:
```
root@ws1t1:~# ./xcalibrate
Pointer devices:
  ID                                Name
   4          Virtual core XTEST pointer
  11      HID 0566:3107 Consumer Control
  13 EloTouchSystems,Inc Elo TouchSystems 2216 AccuTouch® USB Touchmonitor Interface
  15  PixArt Microsoft USB Optical Mouse

Device to calibrate [13]: 

Old calibration:
[[1. 0. 0.]
 [0. 1. 0.]
 [0. 0. 1.]]

Calibrate? [y]: 
Point count (min 3) [4]: 
Disable rotation? [y]: 

Screen width [1600]: 800
Screen height [600]: 
Screen X-offset [0]: 800
Screen Y-offset [0]: 
Geometry: 800x600+800+0
```
